### PR TITLE
docs: add community health files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of groups of people.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Report something that is not working as expected
+title: "[Bug]: "
+labels: ["type:bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: version
+    attributes:
+      label: OptiCore version
+      description: Run `pip show opticore` or check `pyproject.toml`
+      placeholder: e.g., 0.1.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System / Platform
+      description: Include distribution and version where relevant
+      options:
+        - Linux (Ubuntu/Debian)
+        - Linux (RHEL/Fedora/CentOS)
+        - macOS
+        - Windows
+        - Python (pure, no OS dependency)
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      description: Run `python --version`
+      placeholder: e.g., 3.11.8
+    validations:
+      required: true
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug description
+      description: A clear and concise description of what the bug is
+      placeholder: |
+        Briefly describe the bug
+        ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Exactly how to reproduce the bug.
+        Code snippets and inputs are very helpful.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: What actually happened instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: |
+        Add any other context about the problem here, such as:
+        - Full error message (run with `pytest -v` if a test failure)
+        - Volatility and moneyness of the option (if pricing-related)
+        - Any workarounds you've found
+        - Dependencies: ib_async version, nanobind version, etc.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched the existing issues and this has not been reported yet
+          required: true
+        - label: I can reproduce with a minimal, self-contained test case
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/vivek-varma/opticore/discussions
+    about: Please ask and answer general questions here.
+  - name: Security Vulnerabilities
+    url: https://github.com/vivek-varma/opticore/security/advisories/new
+    about: Please report security issues privately using this form.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,64 @@
+name: Feature request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["type:feature"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in improving OptiCore!
+
+        **Note:** Phase 1 is locked. New features outside Phase 1's 6-function scope
+        will be deferred. Please open an issue to discuss before submitting a PR.
+
+        See [ROADMAP.md](https://github.com/vivek-varma/opticore/blob/main/ROADMAP.md) for details.
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Why is this feature needed? What problem does it solve?
+        What use case does it enable?
+      placeholder: |
+        I want to use OptiCore to ...
+        Currently I have to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: A clear and concise description of what you want to happen
+      placeholder: |
+        Add a function `oc.XXX(...)` that ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        What alternatives have you considered?
+        Why is this the best option?
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or mockups about the feature request here
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: phase-1-scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This feature is within Phase 1's 6-function scope (price, iv, greeks, greeks_table, fetch_chain, enrich) — OR — I have discussed this in an issue and gotten agreement to proceed
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Thank you for contributing to OptiCore!
+
+Please review the [AGENT.md](https://github.com/vivek-varma/opticore/blob/main/AGENT.md) for project context before submitting.
+
+## Checklist
+
+- [ ] Tests added / updated — C++ tests pass (`./build_and_test.sh`) and Python tests pass (`pytest tests/python/`)
+- [ ] Numerical accuracy verified (see tolerance ladder in AGENT.md — do not tighten tolerances without asking)
+- [ ] CHANGELOG.md updated with a brief description of the change
+- [ ] Lint clean (`cmake --build build --target lint 2>/dev/null || cmake --build build 2>&1 | grep -v "^--"`)
+- [ ] If changing the Python API: `python -c "import opticore; print(opticore.__version__)"` works
+- [ ] If adding C++ code: new symbols are exported in `src/bindings.cpp` with nanobind ndarray tag
+- [ ] This PR targets the `main` branch
+
+## Notes for Phase 1 contributors
+
+Phase 1 scope is locked to 6 functions (see ROADMAP.md). Please do not expand scope without an ADR. If your change touches `jaeckel.cpp`, the C++ test reference values, or the tolerance ladder — please ask first.
+
+## Questions?
+
+Open a discussion at https://github.com/vivek-varma/opticore/discussions

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+OptiCore is an open-source options pricing library. We take security vulnerabilities seriously.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within OptiCore, please report it responsibly:
+
+**Private vulnerability reporting (preferred):**
+Use GitHub's [Private vulnerability reporting](https://github.com/vivek-varma/opticore/security/advisories/new) form to report the issue directly to the maintainers.
+
+**Disclosure Policy:**
+
+- Please allow a reasonable time for a fix before disclosing any vulnerability publicly
+- We aim to acknowledge reports within 48 hours and provide an estimated timeline for remediation
+- We follow a coordinated disclosure process
+- Researchers who report valid vulnerabilities will be credited in the security advisory when appropriate
+
+**Scope:**
+- Security vulnerabilities in the C++ numerical core (`src/`, `include/`)
+- Security vulnerabilities in the Python API (`python/`)
+- Vulnerabilities in third-party dependencies (ib_async, nanobind, etc.)
+
+**Out of Scope:**
+- Social engineering attacks
+- Physical security issues
+- Denial of service attacks on public endpoints (this is a library, not a service)


### PR DESCRIPTION

## Summary

Adds standard open-source community health files to raise the GitHub community health score to 100%.

Files added:
- `.github/SECURITY.md` — vulnerability disclosure policy with private reporting link
- `.github/CODE_OF_CONDUCT.md` — Contributor Covenant 2.1
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form (OS, Python version, repro steps, expected vs actual)
- `.github/ISSUE_TEMPLATE/feature_request.yml` — structured feature request form with Phase 1 scope check
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links to Discussions and Security Advisory form
- `.github/PULL_REQUEST_TEMPLATE.md` — reviewer checklist with accuracy/compatibility reminders from AGENT.md

## Done when

- `gh api repos/vivek-varma/opticore/community/profile` returns `health_percentage: 100`

## Motivation

Having these files in place (a) earns the "Community Standards" badge which builds trust for AI agents and contributors landing on the repo, and (b) gives users a sane on-ramp to file good bug reports.

Closes #33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established Code of Conduct and Security Policy for community standards and vulnerability reporting
  * Added structured GitHub issue templates for bug reports and feature requests to improve contribution quality
  * Added pull request template to streamline the contribution process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->